### PR TITLE
ci: add lint/typecheck/test workflow + fix pre-existing lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, typecheck & test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src/",
+    "lint": "eslint src/ --max-warnings=0",
     "build-sarif": "tsx src/output/build-sarif.ts",
     "build-llm-json": "tsx src/output/build-llm-json.ts",
     "create-issues": "tsx src/github/sarif-to-issues.ts",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -33,9 +33,8 @@ interface ToolConfig {
   [key: string]: unknown;
 }
 
-interface TscConfig extends ToolConfig {
-  // inherits enabled
-}
+// TscConfig has no extra fields; it just inherits `enabled` from ToolConfig.
+type TscConfig = ToolConfig;
 
 interface EslintConfig extends ToolConfig {
   config_path?: string;
@@ -105,9 +104,8 @@ interface ClippyConfig extends ToolConfig {
   all_targets?: boolean; // Check all targets
 }
 
-interface CargoAuditConfig extends ToolConfig {
-  // No additional config options needed
-}
+// CargoAuditConfig has no extra fields beyond the shared ToolConfig.
+type CargoAuditConfig = ToolConfig;
 
 interface CargoDenyConfig extends ToolConfig {
   config_path?: string;

--- a/src/output/build-llm-json.ts
+++ b/src/output/build-llm-json.ts
@@ -150,7 +150,7 @@ export function buildLlmJson(
   // Enrich with suggested fixes
   const enrichedFindings = sortedFindings.map((finding) => {
     // Remove rawOutput for LLM JSON (keep it lean)
-    const { rawOutput, ...cleanFinding } = finding;
+    const { rawOutput: _rawOutput, ...cleanFinding } = finding;
 
     return {
       ...cleanFinding,

--- a/src/tools/autofix-runner.ts
+++ b/src/tools/autofix-runner.ts
@@ -142,7 +142,7 @@ function runAutofixCommand(
 
   // Build the command args
   // For ruff requires_review fixes, add --unsafe-fixes flag
-  let commandArgs = [...command.args];
+  const commandArgs = [...command.args];
   if (tool === "ruff" && level === "requires_review") {
     // Ruff's "unsafe" fixes require --unsafe-fixes flag to actually apply
     commandArgs.push("--unsafe-fixes");

--- a/src/utils/fingerprints.ts
+++ b/src/utils/fingerprints.ts
@@ -342,7 +342,7 @@ export function extractSublinter(findingOrTitle: Finding | string): string {
     : findingOrTitle.ruleId;
     
   // Check if title has format "sublinter: rule" or "[vibeCheck] sublinter: rule"
-  const titleMatch = title.match(/(?:\[vibeCheck\]\s+)?(\w+)[\s:(\-]/i);
+  const titleMatch = title.match(/(?:\[vibeCheck\]\s+)?(\w+)[\s:(-]/i);
   if (titleMatch) {
     return titleMatch[1].toLowerCase();
   }


### PR DESCRIPTION
## Summary
Adds a CI gate and fixes the pre-existing lint errors it surfaces. Without this, two recent PRs reached `main` with a red `tsc` because nothing ran lint/typecheck/tests on PRs.

### CI (`.github/workflows/ci.yml`)
Runs on every PR and push to `main`: `pnpm lint`, `pnpm typecheck`, `pnpm test` (pnpm 9, Node 20, frozen lockfile, cached).

### Pre-existing lint fixes
- `types.ts` — convert empty `TscConfig`/`CargoAuditConfig` interfaces to type aliases (`no-empty-object-type`)
- `fingerprints.ts` — drop unnecessary `\-` escape in a character class (`no-useless-escape`)
- `build-llm-json.ts` — mark the intentionally-omitted `rawOutput` as `_rawOutput` (`no-unused-vars`)
- `autofix-runner.ts` — `const` instead of `let` for `commandArgs` (`prefer-const`)

### Tooling
- `lint` script now uses `--max-warnings=0` so warnings fail locally and in CI (no drift).

## Verification (local)
- ✅ `pnpm lint` — 0 problems
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm test` — 96/96 passing