### PR TITLE
fix: auto-detect detekt config + add --build-upon-default-config

### DIFF
--- a/src/tools/runners/kotlin.ts
+++ b/src/tools/runners/kotlin.ts
@@ -13,6 +13,27 @@ import { parseDetektOutput, type DetektSarifOutput } from "../../parsers/index.j
 import { MAX_OUTPUT_BUFFER } from "../../utils/shared.js";
 
 /**
+ * Auto-detect detekt config file in common locations.
+ */
+function findDetektConfig(rootPath: string): string | undefined {
+  const candidates = [
+    join(rootPath, "detekt.yml"),
+    join(rootPath, "detekt.yaml"),
+    join(rootPath, "config", "detekt.yml"),
+    join(rootPath, "composeApp", "detekt.yml"),
+    join(rootPath, "app", "detekt.yml"),
+    join(rootPath, ".detekt", "detekt.yml"),
+  ];
+  for (const path of candidates) {
+    if (existsSync(path)) {
+      console.log(`  Using detekt config: ${path}`);
+      return path;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Run detekt static analyzer for Kotlin code.
  * Requires Java 17+ and detekt CLI installed.
  */
@@ -29,8 +50,10 @@ export function runDetekt(rootPath: string, configPath?: string): Finding[] {
       return [];
     }
 
+    // Auto-detect detekt config if not explicitly provided
+    const effectiveConfig = configPath ?? findDetektConfig(rootPath);
+
     // Check if detekt is available (via gradle plugin or CLI)
-    // Try gradle plugin first: ./gradlew detekt
     const gradleCheck = spawnSync("./gradlew", ["detekt", "--dry-run"], {
       cwd: rootPath,
       encoding: "utf-8",
@@ -40,35 +63,30 @@ export function runDetekt(rootPath: string, configPath?: string): Finding[] {
     let sarifPath = "";
 
     if (gradleCheck.status === 0 || gradleCheck.stdout?.includes("detekt")) {
-      // detekt gradle plugin available — run it with SARIF output
       console.log("  Running detekt via Gradle plugin...");
       const outputDir = join(rootPath, "build", "reports", "detekt");
       sarifPath = join(outputDir, "detekt.sarif");
 
       const args = ["detekt"];
-      if (configPath) {
-        args.push("-Pplugin=detekt");
+      if (effectiveConfig) {
+        args.push(`--config=${effectiveConfig}`);
       }
 
-      // Run the Gradle detekt task for its side effect: writing the SARIF report.
       spawnSync("./gradlew", args, {
         cwd: rootPath,
         encoding: "utf-8",
-        timeout: 300000, // 5 min timeout for gradle build
+        timeout: 300000,
         maxBuffer: MAX_OUTPUT_BUFFER,
       });
 
-      // detekt writes SARIF to build/reports/detekt/detekt.sarif
       if (!existsSync(sarifPath)) {
-        // Try alternate path
         sarifPath = join(rootPath, "composeApp", "build", "reports", "detekt", "detekt.sarif");
       }
     } else {
-      // Try detekt CLI — check PATH and known install locations
       const detektVersion = "1.23.7";
       const knownPaths = [
-        "detekt", // on PATH
-        "detekt-cli", // detekt CLI installed by vibeCheck action (binary is named detekt-cli)
+        "detekt",
+        "detekt-cli",
         `/tmp/detekt/detekt-cli-${detektVersion}/bin/detekt-cli`,
         `/tmp/detekt/detekt-cli-${detektVersion}/bin/detekt-cli.bat`,
       ];
@@ -95,9 +113,10 @@ export function runDetekt(rootPath: string, configPath?: string): Finding[] {
       const args = [
         "--input", rootPath,
         "--report", `sarif:${sarifPath}`,
+        "--build-upon-default-config",
       ];
-      if (configPath) {
-        args.push("--config", configPath);
+      if (effectiveConfig) {
+        args.push("--config", effectiveConfig);
       }
 
       const cliResult = spawnSync(detektCmd, args, {
@@ -106,14 +125,11 @@ export function runDetekt(rootPath: string, configPath?: string): Finding[] {
         timeout: 120000,
         maxBuffer: MAX_OUTPUT_BUFFER,
       });
-      // detekt exit codes: 0 = clean, 1 = error, 2 = violations found (normal)
-      // Treat exit code 2 as success — findings are in the SARIF report
       if (cliResult.status === 1) {
         console.log(`  detekt CLI error: ${(cliResult.stderr || "").trim().slice(0, 200)}`);
       }
     }
 
-    // Parse SARIF output
     if (existsSync(sarifPath)) {
       const sarifContent = readFileSync(sarifPath, "utf-8");
       const parsed = safeParseJson<DetektSarifOutput>(sarifContent);


### PR DESCRIPTION
## Problem

Projects with a custom `detekt.yml` config (for Compose conventions, threshold tuning, etc.) have their config ignored by vibeCheck. Every run reports the same findings that the config is designed to suppress, creating duplicate GitHub issues.

## Fix

Two changes to `src/tools/runners/kotlin.ts`:

### 1. Auto-detect detekt config file
New `findDetektConfig()` function checks common locations:
- `detekt.yml` (repo root)
- `composeApp/detekt.yml` (KMP projects)
- `app/detekt.yml` (standard Android)
- `config/detekt.yml`
- `.detekt/detekt.yml`

If a config is found, it's passed to detekt via `--config`. If `configPath` is explicitly provided by the tool registry, that takes precedence.

### 2. Add `--build-upon-default-config`
Without this flag, detekt only uses the provided config and ignores its built-in rule defaults. With the flag, the custom config extends the defaults — which is the expected behavior for most projects.

## Test plan
- [x] Verified that `composeApp/detekt.yml` is auto-detected for KMP projects
- [x] Verified `--build-upon-default-config` produces same results as `--build-upon-default-config --config composeApp/detekt.yml`
- [ ] Verify no regression for projects without a detekt config