### PR TITLE
Gate external dependencies behind a 7-day cooldown

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages:
+  - .
+
+# Supply-chain: external packages must be 7 days old before they resolve. Malicious npm
+# releases are near-always caught within hours (Shai-Hulud ~12h, debug/chalk ~2.5h), so we
+# let the ecosystem find them first. @wolffm/* is EXEMPT (verified): it is the cross-ecosystem
+# deploy path and must install immediately — gating it would stall the whole package sync.
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@wolffm/*'


### PR DESCRIPTION
Makes the dependency-cooldown policy consistent across the ecosystem.

## Why
Most npm supply-chain attacks are caught within **hours** (Shai-Hulud ~12h, the debug/chalk compromise ~2.5h). Refusing to install brand-new package versions lets the ecosystem find the malicious ones before we pull them in.

This repo was previously at one of two extremes:
- **`minimumReleaseAge: 0`** — cooldown switched off entirely, to stop pnpm 11's default 24h gate from holding back `@wolffm/*` auto-sync. That threw away the protection for *every* external package.
- **or the bare default** — a 24h gate with no exemption, which silently gated our own `@wolffm/*` packages, adding friction to the deploy path.

## What
```yaml
minimumReleaseAge: 10080        # 7 days — external packages
minimumReleaseAgeExclude:
  - '@wolffm/*'                 # our deploy path — installs immediately
```
`minimumReleaseAgeExclude` is what makes both possible at once.

Also removes `onlyBuiltDependencies`, which **pnpm 11 removed** in favour of `allowBuilds` — it was dead config (every repo carrying it already had a working `allowBuilds`, so nothing was actually broken).

Existing lockfiles are unaffected; the gate applies at resolution time.